### PR TITLE
Add Firebase login redirect and status check

### DIFF
--- a/src/DndGame.Blazor/FirebaseAuthService.cs
+++ b/src/DndGame.Blazor/FirebaseAuthService.cs
@@ -11,4 +11,7 @@ public class FirebaseAuthService
 
     public ValueTask<string> SignInWithEmailPassword(string email, string password)
         => _js.InvokeAsync<string>("firebaseAuth.signIn", email, password);
+
+    public ValueTask<string> GetCurrentUser()
+        => _js.InvokeAsync<string>("firebaseAuth.getCurrentUser");
 }

--- a/src/DndGame.Blazor/Pages/Index.razor
+++ b/src/DndGame.Blazor/Pages/Index.razor
@@ -1,4 +1,22 @@
 @page "/"
+@inject FirebaseAuthService Auth
 
 <h1>Welcome to DndGame</h1>
-<p><NavLink href="login">Login</NavLink></p>
+
+@if (!string.IsNullOrEmpty(userId))
+{
+    <p>Logged in as @userId</p>
+}
+else
+{
+    <p><NavLink href="login">Login</NavLink></p>
+}
+
+@code {
+    private string? userId;
+
+    protected override async Task OnInitializedAsync()
+    {
+        userId = await Auth.GetCurrentUser();
+    }
+}

--- a/src/DndGame.Blazor/Pages/Login.razor
+++ b/src/DndGame.Blazor/Pages/Login.razor
@@ -1,5 +1,6 @@
 @page "/login"
 @inject FirebaseAuthService Auth
+@inject NavigationManager Navigation
 
 <h3>Login</h3>
 
@@ -7,18 +8,26 @@
 <input @bind="password" type="password" placeholder="Password" />
 <button @onclick="HandleLogin">Login</button>
 
-@if (!string.IsNullOrEmpty(userId))
-{
-    <p>Logged in as @userId</p>
-}
-
 @code {
     private string email = string.Empty;
     private string password = string.Empty;
     private string? userId;
 
+    protected override async Task OnInitializedAsync()
+    {
+        userId = await Auth.GetCurrentUser();
+        if (!string.IsNullOrEmpty(userId))
+        {
+            Navigation.NavigateTo("/");
+        }
+    }
+
     private async Task HandleLogin()
     {
         userId = await Auth.SignInWithEmailPassword(email, password);
+        if (!string.IsNullOrEmpty(userId))
+        {
+            Navigation.NavigateTo("/");
+        }
     }
 }

--- a/src/DndGame.Blazor/wwwroot/firebase-init.js
+++ b/src/DndGame.Blazor/wwwroot/firebase-init.js
@@ -1,0 +1,14 @@
+import { initializeApp } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-app.js";
+
+// Firebase configuration
+const firebaseConfig = {
+  apiKey: "AIzaSyDxC5MjRQQBd1XX7rqK8HzufeUBKhtgRfY",
+  authDomain: "dndgame-e01e1.firebaseapp.com",
+  projectId: "dndgame-e01e1",
+  storageBucket: "dndgame-e01e1.firebasestorage.app",
+  messagingSenderId: "952595537114",
+  appId: "1:952595537114:web:d8ae67651ff041b8c159e3"
+};
+
+// Initialize Firebase
+initializeApp(firebaseConfig);

--- a/src/DndGame.Blazor/wwwroot/firebaseAuth.js
+++ b/src/DndGame.Blazor/wwwroot/firebaseAuth.js
@@ -1,13 +1,18 @@
+import { getAuth, signInWithEmailAndPassword } from "https://www.gstatic.com/firebasejs/12.2.1/firebase-auth.js";
+
 window.firebaseAuth = {
-    init: function (config) {
-        firebase.initializeApp(config);
-    },
     signIn: function (email, password) {
-        return firebase.auth().signInWithEmailAndPassword(email, password)
+        const auth = getAuth();
+        return signInWithEmailAndPassword(auth, email, password)
             .then(userCredential => userCredential.user.uid)
             .catch(err => {
                 console.error(err);
                 return "";
             });
+    },
+    getCurrentUser: function () {
+        const auth = getAuth();
+        const user = auth.currentUser;
+        return user ? user.uid : "";
     }
 };

--- a/src/DndGame.Blazor/wwwroot/index.html
+++ b/src/DndGame.Blazor/wwwroot/index.html
@@ -8,15 +8,8 @@
 <body>
     <div id="app">Loading...</div>
 
-    <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/8.10.0/firebase-auth.js"></script>
-    <script src="firebaseAuth.js"></script>
-    <script>
-        firebaseAuth.init({
-            apiKey: "YOUR_API_KEY",
-            authDomain: "YOUR_AUTH_DOMAIN"
-        });
-    </script>
+    <script type="module" src="firebase-init.js"></script>
+    <script type="module" src="firebaseAuth.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add JS helper to fetch current Firebase user
- expose Firebase auth status via C# service
- redirect authenticated users and show login status on home page
- provide Firebase initialization module and switch auth helpers to ES modules

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1eacdbdd8832dac10fab1a626d6f7